### PR TITLE
[fix]defaultStringLength_fix191

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -14,6 +14,7 @@ class AppServiceProvider extends ServiceProvider
     public function boot()
     {
         //
+        Schema::defaultStringLength(191);
     }
 
     /**


### PR DESCRIPTION
DBの文字列の長さをデフォルトで変更をかけました
理由：laravelがemojiに対応して今までの長さだとmysqlに文字列を超えるため