### PR TITLE
Fix maigration foreign key

### DIFF
--- a/database/migrations/2018_06_06_021313_create_prefectures_table.php
+++ b/database/migrations/2018_06_06_021313_create_prefectures_table.php
@@ -30,6 +30,10 @@ class CreatePrefecturesTable extends Migration
      */
     public function down()
     {
+        Schema::table('prefectures', function (Blueprint $table) {
+            $table->dropForeign('prefectures_RegionID_foreign');
+        });
+
         Schema::dropIfExists('prefectures');
     }
 }

--- a/database/migrations/2018_06_06_021400_create_cards_table.php
+++ b/database/migrations/2018_06_06_021400_create_cards_table.php
@@ -38,6 +38,10 @@ class CreateCardsTable extends Migration
      */
     public function down()
     {
+        Schema::table('cards', function (Blueprint $table) {
+            $table->dropForeign('cards_PrefecturesID_foreign');
+        });
+
         Schema::dropIfExists('cards');
     }
 }

--- a/database/migrations/2018_06_06_021445_create_events_table.php
+++ b/database/migrations/2018_06_06_021445_create_events_table.php
@@ -32,6 +32,10 @@ class CreateEventsTable extends Migration
      */
     public function down()
     {
+        Schema::table('events', function (Blueprint $table) {
+            $table->dropForeign('events_CardID_foreign');
+        });
+
         Schema::dropIfExists('events');
     }
 }

--- a/database/migrations/2018_06_06_021525_create_obtaincards_table.php
+++ b/database/migrations/2018_06_06_021525_create_obtaincards_table.php
@@ -30,6 +30,11 @@ class CreateObtaincardsTable extends Migration
      */
     public function down()
     {
+        Schema::table('obtaincards', function (Blueprint $table) {
+            $table->dropForeign('obtaincards_CardID_foreign');
+            $table->dropForeign('obtaincards_UserID_foreign');
+        });
+
         Schema::dropIfExists('obtaincards');
     }
 }

--- a/database/migrations/2018_06_06_021605_create_obitaintrophys_table.php
+++ b/database/migrations/2018_06_06_021605_create_obitaintrophys_table.php
@@ -30,6 +30,11 @@ class CreateObitaintrophysTable extends Migration
      */
     public function down()
     {
+        Schema::table('obitaintrophys', function (Blueprint $table){
+            $table->dropForeign('obitaintrophys_TrophyID_foreign');
+            $table->dropForeign('obitaintrophys_UserID_foreign');
+        });
+
         Schema::dropIfExists('obitaintrophys');
     }
 }


### PR DESCRIPTION
migrate:reset時に起きる外部キーの関係でデータベースを初期状態に戻せないエラーを解決しました。

https://readouble.com/laravel/5.0/ja/schema.html
スキーマビルダーのtableメソッドを使用して外部キーの制約を外す処理を追加しました。

dropForeignで外部キーの削除を行う場合、外部キーの命名規則がテーブル名とカラム名をつなげ、"_foreign"を最後につけた名前になります。